### PR TITLE
DataFrameClient correcly passes arguments for chunking in query

### DIFF
--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -156,7 +156,7 @@ class DataFrameClient(InfluxDBClient):
         else:
             return results
 
-    def _to_dataframe(rs):
+    def _to_dataframe(self, rs):
         from collections import defaultdict
         result = defaultdict(pd.DataFrame)
         if isinstance(rs, list):

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -156,8 +156,9 @@ class DataFrameClient(InfluxDBClient):
         else:
             return results
 
-    def _to_dataframe(self, rs):
-        result = {}
+    def _to_dataframe(rs):
+        from collections import defaultdict
+        result = defaultdict(pd.DataFrame)
         if isinstance(rs, list):
             return map(self._to_dataframe, rs)
         for key, data in rs.items():
@@ -171,7 +172,7 @@ class DataFrameClient(InfluxDBClient):
             df.set_index('time', inplace=True)
             df.index = df.index.tz_localize('UTC')
             df.index.name = None
-            result[key] = df
+            result[key] = result[key].append(df)
         return result
 
     def _convert_dataframe_to_json(self,

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -145,7 +145,7 @@ class DataFrameClient(InfluxDBClient):
 
         """
         results = super(DataFrameClient, self).query(query,
-                                                     chunked=chunked
+                                                     chunked=chunked,
                                                      chunk_size=chunk_size,
                                                      database=database)
         if query.upper().startswith("SELECT"):

--- a/influxdb/_dataframe_client.py
+++ b/influxdb/_dataframe_client.py
@@ -131,15 +131,23 @@ class DataFrameClient(InfluxDBClient):
                 protocol=protocol)
             return True
 
-    def query(self, query, chunked=False, database=None):
+    def query(self, query, chunked=False, chunk_size=0, database=None):
         """
         Quering data into a DataFrame.
 
-        :param chunked: [Optional, default=False] True if the data shall be
-            retrieved in chunks, False otherwise.
+        :param chunked: Enable to use chunked responses from InfluxDB.
+            With ``chunked`` enabled, one ResultSet is returned per chunk
+            containing all results within that chunk
+        :type chunked: bool
+
+        :param chunk_size: Size of each chunk to tell InfluxDB to use.
+        :type chunk_size: int
 
         """
-        results = super(DataFrameClient, self).query(query, database=database)
+        results = super(DataFrameClient, self).query(query,
+                                                     chunked=chunked
+                                                     chunk_size=chunk_size,
+                                                     database=database)
         if query.upper().startswith("SELECT"):
             if len(results) > 0:
                 return self._to_dataframe(results)


### PR DESCRIPTION
Passing arguments chunked and  chunk_size to the InfluxdbClient query.